### PR TITLE
fix: remove the , "--setParameter", "featureFlagSearchIndexes=true"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /data/db
 EXPOSE 27017
 
 # Start MongoDB when the container runs
-CMD ["mongod", "--bind_ip_all", "--setParameter", "featureFlagSearchIndexes=true"]
+CMD ["mongod", "--bind_ip_all"]


### PR DESCRIPTION
#### **Description**  
This PR removes the `--setParameter featureFlagSearchIndexes=true` flags from the `Dockerfile`.  

#### **Reason for Change**  
- The flags are no longer needed in the current setup.  
- Improves maintainability by keeping only the necessary configurations.  

#### **Impact**  
- No breaking changes expected.  
- Ensures the Docker container runs with the appropriate parameters.  

#### **Testing**  
- Built and ran the Docker container successfully without errors.  

#### **Checklist**  
- [x] Code builds successfully  
- [x] No unintended side effects  

Please review and let me know if any further modifications are required. 🚀  
